### PR TITLE
fix: ensure Notion sync updates assistant and clean server

### DIFF
--- a/scripts/sync_notion.mjs
+++ b/scripts/sync_notion.mjs
@@ -12,6 +12,8 @@ const {
   NOTION_DB_ID,
   OPENAI_API_KEY,
   VECTOR_STORE_ID, // required: target vector store
+  ASST_METAMORPHOSIS,
+  ASST_DEFAULT,
 } = process.env;
 
 function requireEnv(name, val) {
@@ -21,6 +23,8 @@ requireEnv('NOTION_TOKEN', NOTION_TOKEN);
 requireEnv('NOTION_DB_ID', NOTION_DB_ID);
 requireEnv('OPENAI_API_KEY', OPENAI_API_KEY);
 requireEnv('VECTOR_STORE_ID', VECTOR_STORE_ID);
+
+const ASSISTANT_ID = ASST_METAMORPHOSIS || ASST_DEFAULT;
 
 // ===== clients =====
 const notion = new Notion({ auth: NOTION_TOKEN });
@@ -143,6 +147,16 @@ async function updateNotionFileId(pageId, fileId) {
       failed++;
       console.error(`[err] ${filename}: ${e?.message || e}`);
     }
+  }
+
+  if (ASSISTANT_ID) {
+    await openai.beta.assistants.update(ASSISTANT_ID, {
+      tools: [{ type: 'file_search' }],
+      tool_resources: { file_search: { vector_store_ids: [VECTOR_STORE_ID] } },
+    });
+    console.log(`🔗 Assistant updated: ${ASSISTANT_ID}`);
+  } else {
+    console.warn('⚠️ No ASST_* id; skipping assistant update.');
   }
 
   await saveState({ lastSyncISO: new Date().toISOString() });

--- a/server.js
+++ b/server.js
@@ -151,25 +151,6 @@ app.post("/assistant/ask", async (req, res) => {
   }
 });
 
-
-    const data = await r.json();
-    if (!r.ok) {
-      const msg = (data && (data.error?.message || data.message)) || "OpenAI error";
-      return res.status(r.status).json({ ok:false, error: msg });
-    }
-
-    // Responses API: prefer 'output_text'; fallback to first output item.
-    const answer =
-      data.output_text ??
-      (Array.isArray(data.output) && data.output[0]?.content?.[0]?.text) ??
-      "";
-
-    return res.json({ ok:true, answer });
-  } catch (err) {
-    return res.status(500).json({ ok:false, error: err.message });
-  }
-});
-
 // ---------- Start ----------
 const PORT = process.env.PORT || 10000;
 app.listen(PORT, () => console.log(`Assistant ready on http://localhost:${PORT}`));


### PR DESCRIPTION
## Summary
- remove stray duplicate logic from server start to avoid runtime errors
- link Notion sync to assistant by attaching updated vector store

## Testing
- `npm test` *(fails: Missing script "test")*
- `node server.js`
- `node scripts/sync_notion.mjs` *(fails: Missing required env: VECTOR_STORE_ID)*

------
https://chatgpt.com/codex/tasks/task_e_68a2cb623a148329b1d0f0baebcfe4a1