### PR TITLE
fix: use conversation id with responses API

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
     "name": "metlifebot-backend",
     "type": "module",
     "private": true,
+    "engines": {
+        "node": ">=20.0.0"
+    },
     "scripts": {
         "start": "node server.js"
     },

--- a/server.js
+++ b/server.js
@@ -4,6 +4,8 @@ import dotenv from "dotenv";
 import jwt from "jsonwebtoken";
 import path from "path";
 import { fileURLToPath } from "url";
+import crypto from "crypto";
+import fetch from "node-fetch";
 dotenv.config();
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -67,7 +69,12 @@ app.get("/", (_req, res) =>
       body: JSON.stringify({
         assistant_id: ASST_DEFAULT,
         model: model || DEFAULT_MODEL,
-        input: [{ role: "user", content: message }],
+        input: [
+          {
+            role: "user",
+            content: [{ type: "text", text: message }],
+          },
+        ],
       }),
     });
 
@@ -89,28 +96,11 @@ app.get("/", (_req, res) =>
   }
   });
 
-// ---------- Start chat (creates thread) ----------
-app.get("/start-chat", async (_req, res) => {
-  try {
-    const r = await fetch("https://api.openai.com/v1/threads", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-        "Content-Type": "application/json",
-        "OpenAI-Beta": "assistants=v2",
-      },
-      body: "{}",
-    });
-    const data = await r.json();
-    if (!r.ok) {
-      return res
-        .status(r.status)
-        .json({ ok: false, error: data?.error?.message || "OpenAI error" });
-    }
-    res.json({ ok: true, thread_id: data.id });
-  } catch (err) {
-    res.status(500).json({ ok: false, error: err.message });
-  }
+// ---------- Start chat (creates conversation id) ----------
+app.get("/start-chat", (_req, res) => {
+  // Conversation ids can be arbitrary strings. Generate a UUID to track a chat.
+  const thread_id = crypto.randomUUID();
+  res.json({ ok: true, thread_id });
 });
 
 // ---------- Send message on existing thread ----------
@@ -140,10 +130,15 @@ app.post("/send", async (req, res) => {
         "OpenAI-Beta": "assistants=v2",
       },
       body: JSON.stringify({
-        thread_id,
+        conversation: thread_id,
         assistant_id: ASST_DEFAULT,
         model: model || DEFAULT_MODEL,
-        input: [{ role: "user", content: text }],
+        input: [
+          {
+            role: "user",
+            content: [{ type: "text", text }],
+          },
+        ],
       }),
     });
 


### PR DESCRIPTION
## Summary
- generate local UUID for chats instead of creating OpenAI thread
- send conversation id with text-block input to Responses API to avoid `Unknown parameter` errors
- add `node-fetch` polyfill and specify Node 20 runtime to unhang Render deployment

## Testing
- `node --check server.js`
- `node server.js &` then `curl -sSf http://localhost:3001/health | jq '.ok'`


------
https://chatgpt.com/codex/tasks/task_e_68a322b119fc83299b45d9f5c65886ad