### PR TITLE
chore: switch to gpt-4.1-mini

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -63,8 +63,8 @@
         <div>
           <b>Model:</b>
           <select id="model">
-            <option value="gpt-4o-mini" selected>gpt-4o-mini</option>
-            <option value="gpt-4o">gpt-4o</option>
+            <option value="gpt-4.1-mini" selected>gpt-4.1-mini</option>
+            <option value="gpt-4.1">gpt-4.1</option>
           </select>
         </div>
         <div><b>Status:</b> <span id="ready" class="warn">connecting…</span></div>

--- a/server.js
+++ b/server.js
@@ -52,7 +52,7 @@ function boolEnv(name, def = false) {
 
 const OPENAI_API_KEY = requireEnv("OPENAI_API_KEY");
 const ASST_DEFAULT = requireEnv("ASST_DEFAULT");
-const DEFAULT_MODEL = process.env.OPENAI_MODEL || "gpt-4o-mini";
+const DEFAULT_MODEL = process.env.OPENAI_MODEL || "gpt-4.1-mini";
 
 // ---------- OpenAI Client (Responses API) ----------
 const OA_URL = "https://api.openai.com/v1/responses";
@@ -253,7 +253,7 @@ app.post("/chat", async (_req, res) => {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        model: "gpt-4o-mini",
+        model: "gpt-4.1-mini",
         messages: [{ role: "user", content: "Hello" }],
       }),
     });


### PR DESCRIPTION
## Summary
- default to `gpt-4.1-mini` for assistant requests and chat probe
- update local dev UI to list `gpt-4.1` models

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a34a24d478832981f7c4876ba1f6e0