### PR TITLE
feat: add plugin manifest

### DIFF
--- a/public/.well-known/ai-plugin.json
+++ b/public/.well-known/ai-plugin.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": "v1",
+  "name_for_model": "metamorphosis_assistant",
+  "name_for_human": "Metamorphosis Assistant",
+  "description_for_model": "Interact with the Metamorphosis Assistant for skincare guidance and sample information.",
+  "description_for_human": "Chat with the Metamorphosis Assistant to receive skincare recommendations and learn about free samples.",
+  "auth": { "type": "none" },
+  "api": {
+    "type": "openapi",
+    "url": "/openapi.yaml"
+  },
+  "logo_url": "https://via.placeholder.com/256",
+  "contact_email": "support@example.com",
+  "legal_info_url": "https://example.com/legal"
+}

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.1
+info:
+  title: Metamorphosis Assistant API
+  version: '1.0.0'
+  description: API for chatting with the Metamorphosis Assistant.
+servers:
+  - url: http://localhost:10000
+paths:
+  /start-chat:
+    get:
+      summary: Start a new chat thread.
+      parameters:
+        - in: query
+          name: token
+          required: true
+          schema:
+            type: string
+          description: JWT token for authentication.
+      responses:
+        '200':
+          description: Chat thread created.
+  /send:
+    post:
+      summary: Send a message to a chat thread.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                thread_id:
+                  type: string
+                text:
+                  type: string
+                model:
+                  type: string
+      responses:
+        '200':
+          description: Assistant response.


### PR DESCRIPTION
## Summary
- expose OpenAI plugin manifest and OpenAPI schema
- document chat endpoints for start and send operations

## Testing
- `OPENAI_API_KEY=dummy ASST_DEFAULT=asst1 node server.js &`
- `curl -s http://localhost:3001/.well-known/ai-plugin.json`
- `curl -s http://localhost:3001/openapi.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68a3504c49788329a23de150ec4292fe