### PR TITLE
Organize build and sync scripts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
         "node": ">=20.0.0"
     },
     "scripts": {
-        "start": "node server.js"
+        "start": "node server.js",
+        "build": "echo \"no build step\"",
+        "sync:knowledge": "node --env-file=.env ./scripts/sync_knowledge_v4.mjs",
+        "list:vector-files": "node --env-file=.env ./scripts/check_vector_api_v4.mjs"
     },
-    "build": "echo \"no build step\"",
-    "sync:knowledge": "node --env-file=.env ./scripts/sync_knowledge_v4.mjs",
-    "list:vector-files": "node --env-file=.env ./scripts/check_vector_api_v4.mjs",
     "dependencies": {
         "@notionhq/client": "^4.0.2",
         "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- move build, sync:knowledge, and list:vector-files into the scripts block

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a38556c07883299bd953d90f3375ba