### PR TITLE
fix: update OpenAI block type

### DIFF
--- a/server.js
+++ b/server.js
@@ -93,7 +93,7 @@ const OA_HEADERS = {
 };
 
 function blocks(text) {
-  return [{ role: "user", content: [{ type: "text", text: String(text ?? "") }] }];
+  return [{ role: "user", content: [{ type: "input_text", text: String(text ?? "") }] }];
 }
 function extractText(data) {
   return (


### PR DESCRIPTION
## Summary
- use `input_text` blocks for Responses API

## Testing
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68a38b5bfe48832986aa124b3c238c47