### PR TITLE
Implement Notion samples DB helper and tests

### DIFF
--- a/lib/notionSamples.mjs
+++ b/lib/notionSamples.mjs
@@ -1,0 +1,90 @@
+import crypto from 'node:crypto';
+import { Client } from '@notionhq/client';
+
+/**
+ * SamplesDB handles creating or updating sample request pages in Notion.
+ */
+export class SamplesDB {
+  /**
+   * @param {Object} options
+   * @param {string} options.token - Notion API token
+   * @param {string} options.databaseId - Notion database ID for samples
+   * @param {Client} [options.client] - optional Notion client instance for testing
+   */
+  constructor({ token, databaseId, client }) {
+    this.notion = client || new Client({ auth: token });
+    this.databaseId = databaseId;
+  }
+
+  /**
+   * Compute a stable hash of the sample content for change detection.
+   * @param {Object} sample
+   * @returns {string}
+   */
+  static hash(sample) {
+    const json = JSON.stringify(sample, Object.keys(sample).sort());
+    return crypto.createHash('sha256').update(json).digest('hex');
+  }
+
+  /**
+   * Create or update a sample request in Notion.
+   * @param {Object} sample
+   * @returns {Promise<string>} page ID
+   */
+  async upsert(sample) {
+    const contentHash = SamplesDB.hash(sample);
+    const existing = await this.#findByHash(contentHash);
+
+    if (existing) {
+      console.info('Updating Notion sample page', existing.id);
+      await this.notion.pages.update({
+        page_id: existing.id,
+        properties: this.#buildProperties(sample, contentHash)
+      });
+      return existing.id;
+    }
+
+    console.info('Creating Notion sample page');
+    const res = await this.notion.pages.create({
+      parent: { database_id: this.databaseId },
+      properties: this.#buildProperties(sample, contentHash)
+    });
+    return res.id;
+  }
+
+  async #findByHash(hash) {
+    try {
+      const res = await this.notion.databases.query({
+        database_id: this.databaseId,
+        filter: {
+          property: 'Content Hash',
+          rich_text: { equals: hash }
+        }
+      });
+      return res.results[0];
+    } catch (err) {
+      console.error('Notion query failed', err);
+      throw err;
+    }
+  }
+
+  #buildProperties(sample, hash) {
+    return {
+      'Status': { select: { name: sample.status || 'intake' } },
+      'Requester': { title: [{ text: { content: sample.requester || 'Unknown' } }] },
+      'Product': { rich_text: [{ text: { content: sample.product || '' } }] },
+      'Qty': { number: sample.qty || 1 },
+      'Recipient': { rich_text: [{ text: { content: sample.recipient || '' } }] },
+      'Address': { rich_text: [{ text: { content: sample.address || '' } }] },
+      'Purpose': { rich_text: [{ text: { content: sample.purpose || '' } }] },
+      'Deadline': sample.deadline ? { date: { start: sample.deadline } } : undefined,
+      'Policy Result': { rich_text: [{ text: { content: sample.policy_result || '' } }] },
+      'Approval Needed': { checkbox: !!sample.approval_needed },
+      'Approver': sample.approver ? { rich_text: [{ text: { content: sample.approver } }] } : undefined,
+      'Notes': sample.notes ? { rich_text: [{ text: { content: sample.notes } }] } : undefined,
+      'Content Hash': { rich_text: [{ text: { content: hash } }] }
+    };
+  }
+}
+
+export default SamplesDB;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "start": "node server.js",
         "build": "echo \"no build step\"",
         "sync:knowledge": "node --env-file=.env ./scripts/sync_knowledge_v4.mjs",
-        "list:vector-files": "node --env-file=.env ./scripts/check_vector_api_v4.mjs"
+        "list:vector-files": "node --env-file=.env ./scripts/check_vector_api_v4.mjs",
+        "test": "node --test test"
     },
     "dependencies": {
         "@notionhq/client": "^4.0.2",

--- a/test/notionSamples.test.mjs
+++ b/test/notionSamples.test.mjs
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { SamplesDB } from '../lib/notionSamples.mjs';
+
+function createMockClient() {
+  let created = null;
+  let updated = null;
+  let queryFilter = null;
+  return {
+    databases: {
+      async query({ filter }) {
+        queryFilter = filter;
+        if (filter.rich_text && filter.rich_text.equals === 'existing-hash') {
+          return { results: [{ id: 'page1' }] };
+        }
+        return { results: [] };
+      }
+    },
+    pages: {
+      async create({ properties }) {
+        created = properties;
+        return { id: 'new-page' };
+      },
+      async update({ page_id, properties }) {
+        updated = { page_id, properties };
+        return { id: page_id };
+      }
+    },
+    _getState() {
+      return { created, updated, queryFilter };
+    }
+  };
+}
+
+test('creates new page when hash not found', async () => {
+  const mock = createMockClient();
+  const db = new SamplesDB({ token: 'x', databaseId: 'db', client: mock });
+  const sample = { requester: 'Alice', product: 'Lip Balm' };
+  const id = await db.upsert(sample);
+  assert.equal(id, 'new-page');
+  assert.ok(mock._getState().created['Requester']);
+  assert.ok(mock._getState().queryFilter.rich_text.equals);
+});
+
+test('updates page when hash exists', async () => {
+  const mock = createMockClient();
+  const db = new SamplesDB({ token: 'x', databaseId: 'db', client: mock });
+  // Force hash to match existing-hash
+  const sample = { requester: 'Bob', product: 'Lotion' };
+  const hash = SamplesDB.hash(sample);
+  // Monkey patch find to simulate existing
+  mock.databases.query = async () => ({ results: [{ id: 'page1' }] });
+  const id = await db.upsert(sample);
+  assert.equal(id, 'page1');
+  assert.equal(mock._getState().updated.page_id, 'page1');
+  assert.ok(mock._getState().updated.properties['Content Hash']);
+});


### PR DESCRIPTION
## Summary
- add SamplesDB helper to create/update sample request pages in Notion
- add unit tests and test script entry to package.json

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a45f558a008329b965ebd7cac93429