### PR TITLE
Fix server syntax error by removing stray top-level return

### DIFF
--- a/server.js
+++ b/server.js
@@ -190,13 +190,6 @@ const withKnowledge = (payload) => {
 };
 
 
-  // ❗ Responses API rejects tool_resources; only Assistants API accepts it.
-  // We’re using /v1/responses, so do NOT include tool_resources.
-  // If you later switch to Assistants Runs, you can re-enable the next line.
-  // if (tool_resources) out.tool_resources = tool_resources;
-
-  return out;
-};
 async function callResponses(body, { timeoutMs = 45_000 } = {}) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);


### PR DESCRIPTION
## Summary
- Remove leftover tool_resources snippet that introduced a top-level `return` and invalid syntax in `server.js`

## Testing
- `node --check server.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5e9bf6d6c8329a1b4e58b6f01e2ba