### PR TITLE
Fix frontend API endpoints to align with backend routes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -81,7 +81,7 @@
         const email=$devEmail.value.trim();
         if(!email) return;
         $tokStatus.textContent='requesting…';
-        const r=await fetch('/dev/make-token',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email})});
+        const r=await fetch('/dev-token',{method:'POST',headers:{'Content-Type':'application/json'}});
         const j=await r.json().catch(()=>({}));
         if(!r.ok||j?.ok===false){ $tokStatus.textContent='error: '+(j.error||r.status); return; }
         $tokenOut.value=j.token||'';
@@ -96,16 +96,16 @@
 
       async function startThread(){
         $status.textContent='Starting chat…';
-        const r=await fetch('/start-chat');
+        const r=await fetch('/threads', { method: 'POST' });
         const j=await r.json().catch(()=>({}));
-        if(!r.ok||!j?.thread_id){ $status.innerHTML='<span class="err">Start failed</span>'; return false; }
-        thread_id=j.thread_id; $tid.textContent=thread_id; $ready.textContent='ready'; $ready.className='ok'; $status.innerHTML='<span class="ok">Connected.</span> You can chat below.'; $chat.style.display='block'; return true;
+        if(!r.ok||!j?.id){ $status.innerHTML='<span class="err">Start failed</span>'; return false; }
+        thread_id=j.id; $tid.textContent=thread_id; $ready.textContent='ready'; $ready.className='ok'; $status.innerHTML='<span class="ok">Connected.</span> You can chat below.'; $chat.style.display='block'; return true;
       }
 
       async function sendMessage(text){
         if(!thread_id){ const ok=await startThread(); if(!ok) return; }
         $ready.textContent='thinking…'; $ready.className='warn';
-        const r=await fetch('/send',{ method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ thread_id, text }) });
+        const r=await fetch('/assistant/ask',{ method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ thread_id, text }) });
         const j=await r.json().catch(()=>({}));
         if(!r.ok||j?.ok===false){ add('assistant','Oops: '+(j.error||'send failed')); $ready.textContent='error'; $ready.className='err'; return; }
         add('assistant', j.message || j.answer || '(no content)');


### PR DESCRIPTION
The frontend application in `public/index.html` was making calls to several API endpoints that were out of date, causing a "404 Start failed" error on page load.

This commit updates the following API calls in the frontend:
- `GET /start-chat` is changed to `POST /threads` to correctly create a new chat thread. The response handling is also updated to use `response.id`.
- `POST /send` is changed to `POST /assistant/ask` to send messages.
- `POST /dev/make-token` is changed to `POST /dev-token` to request a developer token.

These changes align the frontend with the existing backend routes in `server.js` and resolve the 404 errors, making the application functional.