### PR TITLE
Fix frontend API endpoints and server middleware

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -81,7 +81,7 @@
         const email=$devEmail.value.trim();
         if(!email) return;
         $tokStatus.textContent='requesting…';
-        const r=await fetch('/dev/make-token',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email})});
+        const r=await fetch('/dev-token',{method:'POST',headers:{'Content-Type':'application/json'}});
         const j=await r.json().catch(()=>({}));
         if(!r.ok||j?.ok===false){ $tokStatus.textContent='error: '+(j.error||r.status); return; }
         $tokenOut.value=j.token||'';
@@ -96,16 +96,16 @@
 
       async function startThread(){
         $status.textContent='Starting chat…';
-        const r=await fetch('/start-chat');
+        const r=await fetch('/threads', { method: 'POST' });
         const j=await r.json().catch(()=>({}));
-        if(!r.ok||!j?.thread_id){ $status.innerHTML='<span class="err">Start failed</span>'; return false; }
-        thread_id=j.thread_id; $tid.textContent=thread_id; $ready.textContent='ready'; $ready.className='ok'; $status.innerHTML='<span class="ok">Connected.</span> You can chat below.'; $chat.style.display='block'; return true;
+        if(!r.ok||!j?.id){ $status.innerHTML='<span class="err">Start failed</span>'; return false; }
+        thread_id=j.id; $tid.textContent=thread_id; $ready.textContent='ready'; $ready.className='ok'; $status.innerHTML='<span class="ok">Connected.</span> You can chat below.'; $chat.style.display='block'; return true;
       }
 
       async function sendMessage(text){
         if(!thread_id){ const ok=await startThread(); if(!ok) return; }
         $ready.textContent='thinking…'; $ready.className='warn';
-        const r=await fetch('/send',{ method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ thread_id, text }) });
+        const r=await fetch('/assistant/ask',{ method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ thread_id, text }) });
         const j=await r.json().catch(()=>({}));
         if(!r.ok||j?.ok===false){ add('assistant','Oops: '+(j.error||'send failed')); $ready.textContent='error'; $ready.className='err'; return; }
         add('assistant', j.message || j.answer || '(no content)');

--- a/server.js
+++ b/server.js
@@ -81,7 +81,7 @@ app.use(express.static(path.join(__dirname, "public")));
 // JSON for most routes
 app.use(express.json({ limit: "2mb" }));
 // Also accept raw text on key chat routes (PowerShell & odd clients)
-app.use(["/assistant/ask", "/send"], express.text({ type: "*/*", limit: "1mb" }));
+app.use(["/send"], express.text({ type: "*/*", limit: "1mb" }));
 
 // static GUI (served from /public) — NOW it's safe
 app.use(express.static(path.join(__dirname, "public")));


### PR DESCRIPTION
This commit addresses two issues that were causing the application to fail.

First, the frontend application in `public/index.html` was making calls to several API endpoints that were out of date. This commit updates the following API calls in the frontend:
- `GET /start-chat` is changed to `POST /threads`.
- `POST /send` is changed to `POST /assistant/ask`.
- `POST /dev/make-token` is changed to `POST /dev-token`. The response handling for thread creation is also updated.

Second, a server-side error was caused by conflicting body-parser middleware. The `/assistant/ask` route had both `express.json()` and `express.text()` applied, which led to data corruption. This commit removes the `express.text()` middleware from the `/assistant/ask` route in `server.js` to resolve this conflict.

These changes align the frontend with the backend, fix the server-side error, and should make the application fully functional.