### PR TITLE
feat: integrate assistants api with vector store

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,11 +1,12 @@
 // server.js
-// Chat Completions only (no real Threads) + legacy adapters + dual API bases + diagnostics
+// Chat + Assistants API server with vector-store support
 // Node >= 20, ESM ("type": "module" in package.json)
 
 import express from "express";
 import dotenv from "dotenv";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import OpenAI from "openai";
 
 dotenv.config();
 
@@ -32,6 +33,9 @@ if (!OPENAI_KEY) {
 const DEFAULT_MODEL = process.env.OPENAI_MODEL || "gpt-4o-mini";
 const OPENAI_BASE = "https://api.openai.com/v1";
 const OPENAI_BEARER = `Bearer ${OPENAI_KEY}`;
+const ASST_DEFAULT = process.env.ASST_DEFAULT || ""; // assistant with vector-store attached
+
+const openai = new OpenAI({ apiKey: OPENAI_KEY });
 
 /* -------------------- App -------------------- */
 
@@ -48,6 +52,7 @@ app.use(express.static(path.join(__dirname, "public")));
 
 /* -------------------- Helpers -------------------- */
 
+// Fallback Chat Completions helper (legacy)
 async function chatComplete({ message, messages, model, system, temperature, top_p }) {
   let msgs = Array.isArray(messages) ? messages : [];
   if (!msgs.length && system) msgs.push({ role: "system", content: String(system) });
@@ -71,6 +76,7 @@ async function chatComplete({ message, messages, model, system, temperature, top
 
   const data = await r.json().catch(() => ({}));
   if (!r.ok) {
+    console.error("chatComplete error", data);
     const e = new Error(data?.error?.message || `${r.status} ${r.statusText}`);
     e.response = { status: r.status, data };
     throw e;
@@ -82,8 +88,38 @@ async function chatComplete({ message, messages, model, system, temperature, top
   };
 }
 
-const fakeThreadId = () =>
-  `thread_chat_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+// Assistants API helper with vector-store aware assistant
+async function assistantComplete({ message, thread_id, system }) {
+  if (!ASST_DEFAULT) throw new Error("ASST_DEFAULT not configured");
+  const threadId =
+    thread_id || (await openai.beta.threads.create({})).id;
+  if (!message) throw new Error("message is required");
+  await openai.beta.threads.messages.create(threadId, {
+    role: "user",
+    content: message,
+  });
+  const run = await openai.beta.threads.runs.create(threadId, {
+    assistant_id: ASST_DEFAULT,
+    ...(system ? { instructions: String(system) } : {}),
+  });
+  let status = run.status;
+  while (status === "queued" || status === "in_progress") {
+    await new Promise((r) => setTimeout(r, 500));
+    const r2 = await openai.beta.threads.runs.retrieve(run.id, { thread_id: threadId });
+    status = r2.status;
+  }
+  if (status !== "completed") {
+    throw new Error(`Run ${status}`);
+  }
+  const messages = await openai.beta.threads.messages.list(threadId);
+  const latest = messages.data.find((m) => m.role === "assistant");
+  const answer = latest?.content
+    ?.map((c) => (c.type === "text" ? c.text.value : ""))
+    .join("\n")
+    .trim();
+  return { answer, thread_id: threadId, run_id: run.id, status };
+}
+
 
 /* -------------------- Mount per-base API (both ENV_BASE and /api) -------------------- */
 
@@ -95,21 +131,30 @@ function mountApi(base) {
   // Self-test (quick key/egress check)
   app.post(`${base}/selftest`, async (_req, res) => {
     try {
-      const out = await chatComplete({ message: "Hello" });
+      const helper = ASST_DEFAULT ? assistantComplete : chatComplete;
+      const out = await helper({ message: "Hello" });
       res.json({ ok: true, ...out });
     } catch (e) {
-      res.status(e?.response?.status || 500).json({ ok: false, error: e.message, details: e?.response?.data ?? null });
+      console.error("/selftest error", e);
+      res
+        .status(e?.response?.status || 500)
+        .json({ ok: false, error: e.message, details: e?.response?.data ?? null });
     }
   });
 
   // Preferred endpoint (text/plain or JSON)
   app.post(`${base}/chat`, async (req, res) => {
     try {
-      const body = typeof req.body === "string" ? { message: req.body } : (req.body || {});
-      const out = await chatComplete(body);
+      const body =
+        typeof req.body === "string" ? { message: req.body } : (req.body || {});
+      const helper = ASST_DEFAULT ? assistantComplete : chatComplete;
+      const out = await helper(body);
       res.json({ ok: true, ...out });
     } catch (e) {
-      res.status(e?.response?.status || 400).json({ ok: false, error: e.message || "Bad Request", details: e?.response?.data ?? null });
+      console.error("/chat error", e);
+      res
+        .status(e?.response?.status || 400)
+        .json({ ok: false, error: e.message || "Bad Request", details: e?.response?.data ?? null });
     }
   });
 
@@ -119,35 +164,80 @@ function mountApi(base) {
       const b = typeof req.body === "string" ? { message: req.body } : (req.body || {});
       const text = b.message || b.text || b.input;
       if (!text || !String(text).trim()) return res.status(400).json({ ok: false, error: "message is required" });
-      const out = await chatComplete({ message: text, model: b.model, system: b.system });
-      res.json({ ok: true, ...out, thread_id: b.thread_id ?? null, run_id: null, mode: "chat" });
+      const helper = ASST_DEFAULT ? assistantComplete : chatComplete;
+      const out = await helper({ message: text, thread_id: b.thread_id, system: b.system });
+      res.json({ ok: true, ...out, mode: ASST_DEFAULT ? "assistant" : "chat" });
     } catch (e) {
-      res.status(e?.response?.status || 500).json({ ok: false, error: e.message, details: e?.response?.data ?? null });
+      console.error("/run error", e);
+      res
+        .status(e?.response?.status || 500)
+        .json({ ok: false, error: e.message, details: e?.response?.data ?? null });
     }
   });
 
-  // Legacy Threads-like adapters (no real Threads used)
-  app.post(`${base}/threads`, (_req, res) => res.json({ id: fakeThreadId() }));
+    // Threads API adapters
+    app.post(`${base}/threads`, async (_req, res) => {
+      try {
+        const thread = await openai.beta.threads.create({});
+        res.json({ id: thread.id });
+      } catch (e) {
+        console.error("create thread error", e);
+        res
+          .status(e?.response?.status || 500)
+          .json({ ok: false, error: e.message, details: e?.response?.data ?? null });
+      }
+    });
 
-  app.post(`${base}/threads/:threadId/messages`, (req, res) =>
-    res.json({ ok: true, accepted: true, thread_id: req.params.threadId })
-  );
+    app.post(`${base}/threads/:threadId/messages`, async (req, res) => {
+      try {
+        const { threadId } = req.params;
+        if (!threadId) return res.status(400).json({ ok: false, error: "threadId required" });
+        const b = typeof req.body === "string" ? { message: req.body } : (req.body || {});
+        const text = b.message || b.text || b.input;
+        if (!text) return res.status(400).json({ ok: false, error: "message is required" });
+        await openai.beta.threads.messages.create(threadId, {
+          role: "user",
+          content: text,
+        });
+        res.json({ ok: true, accepted: true, thread_id: threadId });
+      } catch (e) {
+        console.error("add message error", e);
+        res
+          .status(e?.response?.status || 500)
+          .json({ ok: false, error: e.message, details: e?.response?.data ?? null });
+      }
+    });
 
-  app.post(`${base}/threads/:threadId/runs`, async (req, res) => {
-    try {
-      const b = typeof req.body === "string" ? { message: req.body } : (req.body || {});
-      const text = b.message || b.text || b.input || "Continue.";
-      const out = await chatComplete({ message: text, model: b.model, system: b.system });
-      res.json({ ok: true, ...out, thread_id: req.params.threadId, run_id: null, status: "completed", mode: "chat" });
-    } catch (e) {
-      res.status(e?.response?.status || 500).json({ ok: false, error: e.message, details: e?.response?.data ?? null });
-    }
-  });
+    app.post(`${base}/threads/:threadId/runs`, async (req, res) => {
+      try {
+        const { threadId } = req.params;
+        if (!threadId || threadId === "undefined")
+          return res.status(400).json({ ok: false, error: "threadId required" });
+        const b = typeof req.body === "string" ? { message: req.body } : (req.body || {});
+        const text = b.message || b.text || b.input || "Continue.";
+        const out = await assistantComplete({ message: text, thread_id: threadId, system: b.system });
+        res.json({ ok: true, ...out, status: "completed", mode: "assistant" });
+      } catch (e) {
+        console.error("run thread error", e);
+        res
+          .status(e?.response?.status || 500)
+          .json({ ok: false, error: e.message, details: e?.response?.data ?? null });
+      }
+    });
 
-  // Optional: minimal messages list so old UIs don't 404
-  app.get(`${base}/threads/:threadId/messages`, (_req, res) =>
-    res.json({ ok: true, data: [], has_more: false })
-  );
+    app.get(`${base}/threads/:threadId/messages`, async (req, res) => {
+      try {
+        const { threadId } = req.params;
+        if (!threadId) return res.status(400).json({ ok: false, error: "threadId required" });
+        const messages = await openai.beta.threads.messages.list(threadId);
+        res.json({ ok: true, data: messages.data, has_more: messages.has_more });
+      } catch (e) {
+        console.error("list messages error", e);
+        res
+          .status(e?.response?.status || 500)
+          .json({ ok: false, error: e.message, details: e?.response?.data ?? null });
+      }
+    });
 
   // Helpful per-base 404 (AFTER all routes above)
   app.all(`${base}/*`, (req, res) =>
@@ -160,18 +250,53 @@ API_BASES.forEach((b) => mountApi(b));
 
 /* -------------------- Non-API legacy fallbacks -------------------- */
 
-app.post("/threads", (_req, res) => res.json({ id: fakeThreadId() }));
-app.post("/threads/:threadId/messages", (req, res) =>
-  res.json({ ok: true, accepted: true, thread_id: req.params.threadId })
-);
+// Provide root-level thread endpoints for older clients
+app.post("/threads", async (_req, res) => {
+  try {
+    const thread = await openai.beta.threads.create({});
+    res.json({ id: thread.id });
+  } catch (e) {
+    console.error("create thread error", e);
+    res
+      .status(e?.response?.status || 500)
+      .json({ ok: false, error: e.message, details: e?.response?.data ?? null });
+  }
+});
+
+app.post("/threads/:threadId/messages", async (req, res) => {
+  try {
+    const { threadId } = req.params;
+    if (!threadId) return res.status(400).json({ ok: false, error: "threadId required" });
+    const b = typeof req.body === "string" ? { message: req.body } : (req.body || {});
+    const text = b.message || b.text || b.input;
+    if (!text) return res.status(400).json({ ok: false, error: "message is required" });
+    await openai.beta.threads.messages.create(threadId, {
+      role: "user",
+      content: text,
+    });
+    res.json({ ok: true, accepted: true, thread_id: threadId });
+  } catch (e) {
+    console.error("add message error", e);
+    res
+      .status(e?.response?.status || 500)
+      .json({ ok: false, error: e.message, details: e?.response?.data ?? null });
+  }
+});
+
 app.post("/threads/:threadId/runs", async (req, res) => {
   try {
+    const { threadId } = req.params;
+    if (!threadId || threadId === "undefined")
+      return res.status(400).json({ ok: false, error: "threadId required" });
     const b = typeof req.body === "string" ? { message: req.body } : (req.body || {});
     const text = b.message || b.text || b.input || "Continue.";
-    const out = await chatComplete({ message: text, model: b.model, system: b.system });
-    res.json({ ok: true, ...out, thread_id: req.params.threadId, run_id: null, status: "completed", mode: "chat" });
+    const out = await assistantComplete({ message: text, thread_id: threadId, system: b.system });
+    res.json({ ok: true, ...out, status: "completed", mode: "assistant" });
   } catch (e) {
-    res.status(e?.response?.status || 500).json({ ok: false, error: e.message, details: e?.response?.data ?? null });
+    console.error("run thread error", e);
+    res
+      .status(e?.response?.status || 500)
+      .json({ ok: false, error: e.message, details: e?.response?.data ?? null });
   }
 });
 
@@ -202,6 +327,7 @@ app.get("*", (req, res, next) => {
 
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
-  console.log(`[chat-only] model=${DEFAULT_MODEL}`);
+  if (ASST_DEFAULT) console.log(`[assistant] id=${ASST_DEFAULT}`);
+  else console.log(`[chat-only] model=${DEFAULT_MODEL}`);
   console.log(`API bases mounted at: ${API_BASES.join(", ")}`);
 });


### PR DESCRIPTION
## Summary
- upgrade server to use OpenAI Assistants API and vector-store aware assistant
- add real thread, message, and run routes with improved error logging
- expose root-level thread endpoints for legacy clients
- fix run status polling by retrieving runs with proper thread context

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8cb08682c8329a17c59b816cec471